### PR TITLE
chore: move @types/node into dev deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
 	"license": "MIT OR Apache-2.0",
 	"devDependencies": {
 		"@cloudflare/workers-types": "^1.0.1",
+		"@types/node": "^13.13.5",
 		"prettier": "^2.0.5",
 		"source-map-loader": "^0.2.4",
 		"source-map-support": "^0.5.12",
@@ -26,7 +27,6 @@
 		"@cfworker/cosmos": "^1.1.3",
 		"@cfworker/sentry": "^1.1.1",
 		"@cfworker/uuid": "^1.1.4",
-		"@types/node": "^13.13.5",
 		"tiny-request-router": "^1.2.2"
 	}
 }


### PR DESCRIPTION
This PR moves the @types/node dependency from regular dependencies into dev deps, as the title would suggest